### PR TITLE
Maybe make two items protected in order to allow subclasses

### DIFF
--- a/lib/Auth/Source/SQL.php
+++ b/lib/Auth/Source/SQL.php
@@ -52,7 +52,7 @@ class SQL extends \SimpleSAML\Module\core\Auth\UserPassBase
      * The username and password will be available as :username and :password.
      * @var string
      */
-    private string $query;
+    protected string $query;
 
     /**
      * Constructor for this authentication source.
@@ -95,7 +95,7 @@ class SQL extends \SimpleSAML\Module\core\Auth\UserPassBase
      *
      * @return \PDO  The database connection.
      */
-    private function connect(): PDO
+    protected function connect(): PDO
     {
         try {
             $db = new PDO($this->dsn, $this->username, $this->password, $this->options);


### PR DESCRIPTION
If connect() and $query are changed to `protected` a subclass can use it's own query and connect() to the database in order to verify passwords in their own way. Only the connect() really needs to change but it seemed like a good idea to use the $query parameter as well.

One example subclass I have as a use case is using the php password_verify() function to check the password in order to make database setup easier. This is done to allow use of mariadb or postgresql without needing specific database functions for either case. I would really like to also work to upstream the PasswordVerify.php class (maybe renamed to something more appropriate) if there is interest in providing this option in the main repository.

https://github.com/filesender/filesender/blob/development/scripts/simplesamlphp/passwordverify/PasswordVerify.php

Hopefully this is the correct location to offer PRs that might update the main SimpleSAMLphp files for this module.