### PR TITLE
A new PasswordVerify.php that does hashing in php rather than on the SQL side

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -234,7 +234,7 @@ Since the above is using the default passwordhash column name this can
 then be used with the following addition to authsources.php.
 
 ```php
-'filesender-dbauth' => [
+'smalldb-dbauth' => [
     'sqlauth:PasswordVerify',
     'dsn' => 'pgsql:host=...',
     'username' => 'dbuser',

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -2,7 +2,7 @@
 =============
 
 These are authentication modules for authenticating a user against a
-SQL database. 
+SQL database.
 
 The SQL module performs password verification in the database itself
 using database functions such as sha512 and storing a salt in the
@@ -12,8 +12,6 @@ to ask the least of the database either because there is minimal
 support in the database or to allow the same code to work against many
 databases without modification. More information on PasswordVerify is
 provided at the end of this document.
-
-
 
 Options
 -------
@@ -194,11 +192,10 @@ used instead as an additional security measure.
 
 One way hashing algorithms like MD5 or SHA1 are considered insecure and should therefore be avoided.
 
-
 The PasswordVerify module
 -------------------------
 
-Users and passwords have to be set in the database by other means than the PasswordVerify module. 
+Users and passwords have to be set in the database by other means than the PasswordVerify module.
 
 For example:
 
@@ -212,7 +209,7 @@ For example:
     );
 ```
 
-A user can be added with a known password "FIXMEPASSWORD" as shown below. 
+A user can be added with a known password "FIXMEPASSWORD" as shown below.
 
 ```php
 $dsn = "pgsql:host=...";

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -54,7 +54,7 @@ class PasswordVerify extends SQL
     /**
      * The column in the result set containing the passwordhash.
      */
-    protected ?string $passwordhashcolumn = null;
+    protected string $passwordhashcolumn = 'passwordhash';
 
     /**
      * Constructor for this authentication source.
@@ -69,10 +69,6 @@ class PasswordVerify extends SQL
 
         if (array_key_exists('passwordhashcolumn', $config)) {
             $this->passwordhashcolumn = $config['passwordhashcolumn'];
-        }
-
-        if ($this->passwordhashcolumn === null) {
-            $this->passwordhashcolumn = 'passwordhash';
         }
     }
 

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -10,8 +10,6 @@ use PDOException;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Error;
 use SimpleSAML\Logger;
-<<<<<<< HEAD
-=======
 use SimpleSAML\Module\sqlauth\Auth\Source\SQL;
 
 use function array_key_exists;
@@ -23,7 +21,6 @@ use function is_null;
 use function password_verify;
 use function sprintf;
 use function strval;
->>>>>>> 074b35da3ec9ca71533459aab2e426db0be6812b
 
 /**
  * Simple SQL authentication source
@@ -33,15 +30,9 @@ use function strval;
  * password_verify() function to allow for example PASSWORD_ARGON2ID to be used
  * for verification.
  *
-<<<<<<< HEAD
- * While this class has a query parameter as the SQL class does the meaning 
- * is different. The query for this class should return at least a column 
- * called passwordhash containing the hashed password which was generated 
-=======
  * While this class has a query parameter as the SQL class does the meaning
  * is different. The query for this class should return at least a column
  * called passwordhash containing the hashed password which was generated
->>>>>>> 074b35da3ec9ca71533459aab2e426db0be6812b
  * for example using
  *    password_hash('hello', PASSWORD_ARGON2ID );
  *

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -118,9 +118,12 @@ class PasswordVerify extends SQL
                         !array_key_exists($this->passwordhashcolumn, $row)
                         || is_null($row[$this->passwordhashcolumn])
                     ) {
-                        Logger::error('sqlauth:' . $this->authId .
-                                      ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
-                        throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                        Logger::error(sprintf(
+                            'sqlauth:%s: column `%s` must be in every result tuple.',
+                            $this->authId,
+                            $this->passwordhashcolumn,
+                        ));
+                        throw new Error\Error('WRONGUSERPASS');                        
                     }
                     if ($pwhash) {
                         if ($pwhash != $row[$this->passwordhashcolumn]) {

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\sqlauth\Auth\Source;
 
+use SimpleSAML\Error;
 use SimpleSAML\Logger;
 use SimpleSAML\Module\sqlauth\Auth\Source\SQL;
 
@@ -13,6 +14,7 @@ use function count;
 use function implode;
 use function is_null;
 use function password_verify;
+use function sprintf;
 
 /**
  * Simple SQL authentication source
@@ -97,9 +99,11 @@ class PasswordVerify extends SQL
             if ($x === 0) {
                 if (count($data) === 0) {
                     // No rows returned - invalid username/password
-                    Logger::error('sqlauth:' . $this->authId .
-                                  ': No rows in result set. Probably wrong username/password.');
-                    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                    Logger::error(sprintf(
+                        'sqlauth:%s: No rows in result set. Probably wrong username/password.',
+                        $this->authId,
+                    ));
+                    throw new Error\Error('WRONGUSERPASS');
                 }
             }
 
@@ -116,16 +120,21 @@ class PasswordVerify extends SQL
                     !array_key_exists($this->passwordhashcolumn, $row)
                     || is_null($row[$this->passwordhashcolumn])
                 ) {
-                    Logger::error('sqlauth:' . $this->authId .
-                                  ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
-                    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                    Logger::error(sprintf(
+                        'sqlauth:%s: column `%s` must be in every result tuple.',
+                        $this->authId,
+                        $this->passwordhashcolumn,
+                    ));
+                    throw new Error\Error('WRONGUSERPASS');
                 }
                 if ($pwhash) {
                     if ($pwhash != $row[$this->passwordhashcolumn]) {
-                        Logger::error('sqlauth:' . $this->authId
-                                    . ': column ' . $this->passwordhashcolumn
-                                    . ' must be THE SAME in every result tuple.');
-                        throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                        Logger::error(sprintf(
+                            'sqlauth:%s: column %s must be THE SAME in every result tuple.',
+                            $this->authId,
+                            $this->passwordhashcolumn,
+                        ));
+                        throw new Error\Error('WRONGUSERPASS');
                     }
                 }
                 $pwhash = $row[$this->passwordhashcolumn];
@@ -136,9 +145,12 @@ class PasswordVerify extends SQL
              */
             if (is_null($pwhash)) {
                 if ($pwhash != $row[$this->passwordhashcolumn]) {
-                    Logger::error('sqlauth:' . $this->authId .
-                                  ': column ' . $this->passwordhashcolumn . ' does not contain a password hash.');
-                    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                    Logger::error(sprintf(
+                        'sqlauth:%s: column `%s` does not contain a password hash.',
+                        $this->authId,
+                        $this->passwordhashcolumn,
+                    ));
+                    throw new Error\Error('WRONGUSERPASS');
                 }
             }
 
@@ -147,16 +159,22 @@ class PasswordVerify extends SQL
              * Now to check if the password the user supplied is actually valid
              */
             if (!password_verify($password, $pwhash)) {
-                Logger::error('sqlauth:' . $this->authId . ': password is incorrect.');
-                throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                Logger::error(sprintf(
+                    'sqlauth:%s: password is incorrect.',
+                    $this->authId,
+                ));
+                throw new Error\Error('WRONGUSERPASS');
             }
 
 
             $this->extractAttributes($attributes, $data, [$this->passwordhashcolumn]);
         }
 
-        Logger::info('sqlauth:' . $this->authId . ': Attributes: ' .
-                     implode(',', array_keys($attributes)));
+        Logger::info(sprintf(
+            'sqlauth:%s: Attributes: %s',
+            $this->authId,
+            implode(',', array_keys($attributes)),
+        ));
 
         return $attributes;
     }

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -109,7 +109,7 @@ class PasswordVerify extends SQL
                     Logger::error(sprintf(
                         'sqlauth:%s: No rows in result set. Probably wrong username/password.',
                         $this->authId,
-                    ));                    
+                    ));
                     throw new Error\Error('WRONGUSERPASS');
                 }
 
@@ -123,7 +123,7 @@ class PasswordVerify extends SQL
                             $this->authId,
                             $this->passwordhashcolumn,
                         ));
-                        throw new Error\Error('WRONGUSERPASS');                        
+                        throw new Error\Error('WRONGUSERPASS');
                     }
                     if ($pwhash) {
                         if ($pwhash != $row[$this->passwordhashcolumn]) {
@@ -152,7 +152,7 @@ class PasswordVerify extends SQL
                         throw new Error\Error('WRONGUSERPASS');
                     }
                 }
-                
+
                 /**
                  * VERIFICATION!
                  * Now to check if the password the user supplied is actually valid

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\sqlauth\Auth\Source;
+
+use Exception;
+use PDO;
+use PDOException;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Error;
+use SimpleSAML\Logger;
+
+/**
+ * Simple SQL authentication source
+ *
+ * This class is very much like the SQL class. The major difference is that
+ * instead of using SHA2 and other functions in the database we use the PHP
+ * password_verify() function to allow for example PASSWORD_ARGON2ID to be used
+ * for verification.
+ *
+ * While this class has a query parameter as the SQL class does the meaning 
+ * is different. The query for this class should return at least a column 
+ * called passwordhash containing the hashed password which was generated 
+ * for example using
+ *    password_hash('hello', PASSWORD_ARGON2ID );
+ *
+ * Auth only passes if the PHP code below returns true.
+ *   password_verify($password, row['passwordhash'] );
+ *
+ * Unlike the SQL class the username is the only parameter passed to the SQL query,
+ * the query can not perform password checks, they are performed by the PHP code 
+ * in this class using password_verify().
+ *
+ * If there are other columns in the returned data they are assumed to be attributes
+ * you would like to be returned through SAML.
+ *
+ * @package SimpleSAMLphp
+ */
+
+class PasswordVerify extends \SimpleSAML\Module\sqlauth\Auth\Source\SQL
+{
+    /**
+     * The column in the result set containing the passwordhash.
+     */
+    private $passwordhashcolumn;
+
+    /**
+     * Constructor for this authentication source.
+     *
+     * @param array $info  Information about this authentication source.
+     * @param array $config  Configuration.
+     */
+    public function __construct(array $info, array $config)    
+    {
+        assert(is_array($info));
+        assert(is_array($config));
+
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+
+        if( array_key_exists('passwordhashcolumn', $config )) {
+            $this->passwordhashcolumn = $config['passwordhashcolumn'];
+        }
+        if( !$this->passwordhashcolumn ) {
+            $this->passwordhashcolumn = 'passwordhash';
+        }
+    }
+
+
+    /**
+     * Extract SQL columns into SAML attribute array
+     *
+     * @param array  $data  Associative array from database in the format of PDO fetchAll
+     * @param array  $forbiddenAttributes An array of attributes to never return
+     * @return array  Associative array with the users attributes.
+     */
+    protected function extractAttributes( $data, $forbiddenAttributes = array() )
+    {
+        $attributes = [];
+        foreach ($data as $row) {
+            foreach ($row as $name => $value) {
+                if ($value === null) {
+                    continue;
+                }
+                if (in_array($name, $forbiddenAttributes)) {
+                    continue;
+                }
+               
+
+                $value = (string) $value;
+
+                if (!array_key_exists($name, $attributes)) {
+                    $attributes[$name] = [];
+                }
+
+                if (in_array($value, $attributes[$name], true)) {
+                    // Value already exists in attribute
+                    continue;
+                }
+
+                $attributes[$name][] = $value;
+            }
+        }
+        
+        return $attributes;
+    }
+
+
+    /**
+     * Attempt to log in using the given username and password.
+     *
+     * On a successful login, this function should return the users attributes. On failure,
+     * it should throw an exception. If the error was caused by the user entering the wrong
+     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     *
+     * Note that both the username and the password are UTF-8 encoded.
+     *
+     * @param string $username  The username the user wrote.
+     * @param string $password  The password the user wrote.
+     * @return array  Associative array with the users attributes.
+     */
+    protected function login(string $username, string $password): array
+    {
+        assert(is_string($username));
+        assert(is_string($password));
+
+
+        $db = $this->connect();
+        
+        try {
+            $sth = $db->prepare($this->query);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to prepare query: '.$e->getMessage());
+        }
+
+
+        try {
+            $sth->execute(['username' => $username]);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to execute sql: '.$this->query.' query: '.$e->getMessage());
+        }
+
+        try {
+            $data = $sth->fetchAll(\PDO::FETCH_ASSOC);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to fetch result set: '.$e->getMessage());
+        }
+
+        \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Got '.count($data).
+            ' rows from database');
+
+        if (count($data) === 0) {
+            // No rows returned - invalid username/password
+            \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                ': No rows in result set. Probably wrong username/password.');
+            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+        }
+
+        /**
+         * Sanity check, passwordhash must be in each resulting tuple and must have
+         * the same value in every tuple.
+         * 
+         * Note that $pwhash will contain the passwordhash value after this loop.
+         */
+        $pwhash = null;
+        foreach ($data as $row) {
+            if (!array_key_exists($this->passwordhashcolumn, $row)
+                || is_null($row[$this->passwordhashcolumn]))
+            {
+                \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                          ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
+                throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            }
+            if( $pwhash ) {
+                if( $pwhash != $row[$this->passwordhashcolumn] ) {
+                    \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                              ': column ' . $this->passwordhashcolumn . ' must be THE SAME in every result tuple.');
+                    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                }
+            }
+            $pwhash = $row[$this->passwordhashcolumn];
+        }
+        /**
+         * This should never happen as the count(data) test above would have already thrown.
+         * But checking twice doesn't hurt.
+         */
+        if( is_null($pwhash)) {
+            if( $pwhash != $row[$this->passwordhashcolumn] ) {
+                \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                          ': column ' . $this->passwordhashcolumn . ' does not contain a password hash.');
+                throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            }
+        }
+
+        /**
+         * VERIFICATION!
+         * Now to check if the password the user supplied is actually valid
+         */
+        if( !password_verify( $password, $pwhash )) {
+            \SimpleSAML\Logger::error('sqlauth:'.$this->authId. ': password is incorrect.');
+            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+        }
+
+        
+        $attributes = $this->extractAttributes( $data, array($this->passwordhashcolumn) );
+
+        \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Attributes: '.
+            implode(',', array_keys($attributes)));
+
+        return $attributes;
+    }
+}

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -122,8 +122,9 @@ class PasswordVerify extends SQL
                 }
                 if ($pwhash) {
                     if ($pwhash != $row[$this->passwordhashcolumn]) {
-                        Logger::error('sqlauth:' . $this->authId .
-                                      ': column ' . $this->passwordhashcolumn . ' must be THE SAME in every result tuple.');
+                        Logger::error('sqlauth:' . $this->authId
+                                    . ': column ' . $this->passwordhashcolumn
+                                    . ' must be THE SAME in every result tuple.');
                         throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                     }
                 }

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -98,9 +98,9 @@ class PasswordVerify extends SQL
         $numQueries = count($this->query);
         for ($x = 0; $x < $numQueries; $x++) {
 
-            $data = $this->executeQuery( $this->query[$x], $params )
+            $data = $this->executeQuery($this->query[$x], $params);
             
-            Logger::info('sqlauth:'.$this->authId.': Got '.count($data).
+            Logger::info('sqlauth:' . $this->authId . ': Got ' . count($data) .
                          ' rows from database');
 
             if ($x === 0) {

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -106,8 +106,10 @@ class PasswordVerify extends SQL
             if ($x === 0) {
                 if (count($data) === 0) {
                     // No rows returned - invalid username/password
-                    Logger::error('sqlauth:' . $this->authId .
-                                  ': No rows in result set. Probably wrong username/password.');
+                    Logger::error(sprintf(
+                        'sqlauth:%s: No rows in result set. Probably wrong username/password.',
+                        $this->authId,
+                    ));                    
                     throw new Error\Error('WRONGUSERPASS');
                 }
 

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -100,14 +100,14 @@ class PasswordVerify extends SQL
 
             $data = $this->executeQuery( $this->query[$x], $params )
             
-            \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Got '.count($data).
-                                     ' rows from database');
+            Logger::info('sqlauth:'.$this->authId.': Got '.count($data).
+                         ' rows from database');
 
             if ($x === 0) {
                 if (count($data) === 0) {
                     // No rows returned - invalid username/password
-                    \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
-                                              ': No rows in result set. Probably wrong username/password.');
+                    Logger::error('sqlauth:'.$this->authId.
+                                  ': No rows in result set. Probably wrong username/password.');
                     throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                 }
                 /* Only the first query should be passed the password, as that is the only
@@ -128,14 +128,14 @@ class PasswordVerify extends SQL
                 if (!array_key_exists($this->passwordhashcolumn, $row)
                     || is_null($row[$this->passwordhashcolumn]))
                 {
-                    \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
-                                              ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
+                    Logger::error('sqlauth:'.$this->authId.
+                                  ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
                     throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                 }
                 if( $pwhash ) {
                     if( $pwhash != $row[$this->passwordhashcolumn] ) {
-                        \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
-                                                  ': column ' . $this->passwordhashcolumn . ' must be THE SAME in every result tuple.');
+                        Logger::error('sqlauth:'.$this->authId.
+                                      ': column ' . $this->passwordhashcolumn . ' must be THE SAME in every result tuple.');
                         throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                     }
                 }
@@ -147,8 +147,8 @@ class PasswordVerify extends SQL
              */
             if( is_null($pwhash)) {
                 if( $pwhash != $row[$this->passwordhashcolumn] ) {
-                    \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
-                                              ': column ' . $this->passwordhashcolumn . ' does not contain a password hash.');
+                    Logger::error('sqlauth:'.$this->authId.
+                                  ': column ' . $this->passwordhashcolumn . ' does not contain a password hash.');
                     throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                 }
             }
@@ -158,7 +158,7 @@ class PasswordVerify extends SQL
              * Now to check if the password the user supplied is actually valid
              */
             if( !password_verify( $password, $pwhash )) {
-                \SimpleSAML\Logger::error('sqlauth:'.$this->authId. ': password is incorrect.');
+                Logger::error('sqlauth:'.$this->authId. ': password is incorrect.');
                 throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
             }
 
@@ -166,8 +166,8 @@ class PasswordVerify extends SQL
             $this->extractAttributes( $attributes, $data, array($this->passwordhashcolumn) );
         }
         
-        \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Attributes: '.
-            implode(',', array_keys($attributes)));
+        Logger::info('sqlauth:'.$this->authId.': Attributes: '.
+                     implode(',', array_keys($attributes)));
 
         return $attributes;
     }

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -84,7 +84,7 @@ class PasswordVerify extends SQL
      * @param array  $forbiddenAttributes An array of attributes to never return
      * @return array  Associative array with the users attributes.
      */
-    protected function extractAttributes( $data, $forbiddenAttributes = array() )
+    protected function extractAttributes($data, $forbiddenAttributes = array()): array
     {
         $attributes = [];
         foreach ($data as $row) {

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -92,13 +92,13 @@ class PasswordVerify extends SQL
         $this->verifyUserNameWithRegex( $username );
         
         $db = $this->connect();
-        $params = ['username' => $username, 'password' => $password];
+        $params = ['username' => $username];
         $attributes = [];
 
         $numQueries = count($this->query);
         for ($x = 0; $x < $numQueries; $x++) {
 
-            $data = $this->executeQuery($this->query[$x], $params);
+            $data = $this->executeQuery($db, $this->query[$x], $params);
             
             Logger::info('sqlauth:' . $this->authId . ': Got ' . count($data) .
                          ' rows from database');
@@ -110,10 +110,6 @@ class PasswordVerify extends SQL
                                   ': No rows in result set. Probably wrong username/password.');
                     throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
                 }
-                /* Only the first query should be passed the password, as that is the only
-                 * one used for authentication. Subsequent queries are only used for
-                 * getting attribute lists, so only need the username. */
-                unset($params['password']);
             }
                 
 

--- a/src/Auth/Source/PasswordVerify.php
+++ b/src/Auth/Source/PasswordVerify.php
@@ -30,9 +30,9 @@ use function strval;
  * password_verify() function to allow for example PASSWORD_ARGON2ID to be used
  * for verification.
  *
- * While this class has a query parameter as the SQL class does the meaning 
- * is different. The query for this class should return at least a column 
- * called passwordhash containing the hashed password which was generated 
+ * While this class has a query parameter as the SQL class does the meaning
+ * is different. The query for this class should return at least a column
+ * called passwordhash containing the hashed password which was generated
  * for example using
  *    password_hash('hello', PASSWORD_ARGON2ID );
  *
@@ -40,7 +40,7 @@ use function strval;
  *   password_verify($password, row['passwordhash'] );
  *
  * Unlike the SQL class the username is the only parameter passed to the SQL query,
- * the query can not perform password checks, they are performed by the PHP code 
+ * the query can not perform password checks, they are performed by the PHP code
  * in this class using password_verify().
  *
  * If there are other columns in the returned data they are assumed to be attributes
@@ -62,7 +62,7 @@ class PasswordVerify extends SQL
      * @param array $info  Information about this authentication source.
      * @param array $config  Configuration.
      */
-    public function __construct(array $info, array $config)    
+    public function __construct(array $info, array $config)
     {
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
@@ -84,7 +84,7 @@ class PasswordVerify extends SQL
      * @param array  $forbiddenAttributes An array of attributes to never return
      * @return array  Associative array with the users attributes.
      */
-    protected function extractAttributes($data, $forbiddenAttributes = array()): array
+    protected function extractAttributes(array $data, array $forbiddenAttributes = []): array
     {
         $attributes = [];
         foreach ($data as $row) {
@@ -95,7 +95,6 @@ class PasswordVerify extends SQL
                 if (in_array($name, $forbiddenAttributes)) {
                     continue;
                 }
-               
 
                 $value = strval($value);
 
@@ -111,7 +110,7 @@ class PasswordVerify extends SQL
                 $attributes[$name][] = $value;
             }
         }
-        
+
         return $attributes;
     }
 
@@ -132,7 +131,7 @@ class PasswordVerify extends SQL
     protected function login(string $username, string $password): array
     {
         $db = $this->connect();
-        
+
         try {
             $sth = $db->prepare($this->query);
         } catch (PDOException $e) {
@@ -183,14 +182,15 @@ class PasswordVerify extends SQL
         /**
          * Sanity check, passwordhash must be in each resulting tuple and must have
          * the same value in every tuple.
-         * 
+         *
          * Note that $pwhash will contain the passwordhash value after this loop.
          */
         $pwhash = null;
         foreach ($data as $row) {
-            if (!array_key_exists($this->passwordhashcolumn, $row)
-                || is_null($row[$this->passwordhashcolumn]))
-            {
+            if (
+                !array_key_exists($this->passwordhashcolumn, $row)
+                || is_null($row[$this->passwordhashcolumn])
+            ) {
                 Logger::error(sprintf(
                     'sqlauth:%s: column %s must be in every result tuple.',
                     $this->authId,
@@ -234,7 +234,6 @@ class PasswordVerify extends SQL
             throw new Error\Error('WRONGUSERPASS');
         }
 
-        
         $attributes = $this->extractAttributes($data, [$this->passwordhashcolumn]);
 
         Logger::info(sprintf(

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -163,7 +163,7 @@ class SQL extends UserPassBase
      * @param array  $forbiddenAttributes An array of attributes to never return
      * @return $attributes
      */
-    protected function extractAttributes( &$attributes, $data, $forbiddenAttributes = array() )
+    protected function extractAttributes(&$attributes, $data, $forbiddenAttributes = [])
     {
         foreach ($data as $row) {
             foreach ($row as $name => $value) {
@@ -189,7 +189,7 @@ class SQL extends UserPassBase
             }
         }
         return $attributes;
-    }    
+    }
 
     /**
      * Execute the query with given parameters and return the tuples that result.
@@ -198,7 +198,7 @@ class SQL extends UserPassBase
      * @param array  $params parameters to the SQL query
      * @return tuples that result
      */
-    protected function executeQuery( PDO $db, string $query, array $params ): array
+    protected function executeQuery(PDO $db, string $query, array $params): array
     {
         try {
             $sth = $db->prepare($query);
@@ -229,7 +229,7 @@ class SQL extends UserPassBase
      *
      * @param string $username  The username the user wrote.
      */
-    protected function verifyUserNameWithRegex( string $username ): void
+    protected function verifyUserNameWithRegex(string $username): void
     {
         if ($this->username_regex !== null) {
             if (!preg_match($this->username_regex, $username)) {
@@ -239,7 +239,7 @@ class SQL extends UserPassBase
             }
         }
     }
-    
+
     /**
      * Attempt to log in using the given username and password.
      *
@@ -255,7 +255,7 @@ class SQL extends UserPassBase
      */
     protected function login(string $username, string $password): array
     {
-        $this->verifyUserNameWithRegex( $username );
+        $this->verifyUserNameWithRegex($username);
 
         $db = $this->connect();
         $params = ['username' => $username, 'password' => $password];
@@ -263,9 +263,8 @@ class SQL extends UserPassBase
 
         $numQueries = count($this->query);
         for ($x = 0; $x < $numQueries; $x++) {
-            
             $data = $this->executeQuery($db, $this->query[$x], $params);
-            
+
             Logger::info('sqlauth:' . $this->authId . ': Got ' . count($data) .
                 ' rows from database');
 
@@ -286,8 +285,7 @@ class SQL extends UserPassBase
             * which are present in more than one row will become multivalued. null values and
             * duplicate values will be skipped. All values will be converted to strings.
              */
-            $this->extractAttributes( $attributes, $data, array() );
-            
+            $this->extractAttributes($attributes, $data, []);
         }
 
         Logger::info('sqlauth:' . $this->authId . ': Attributes: ' . implode(',', array_keys($attributes)));

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -198,10 +198,10 @@ class SQL extends UserPassBase
      * @param array  $params parameters to the SQL query
      * @return tuples that result
      */
-    protected function executeQuery( string $query, array $params ): array
+    protected function executeQuery( PDO $db, string $query, array $params ): array
     {
         try {
-            $sth = $db->prepare($this->query[$x]);
+            $sth = $db->prepare($query);
         } catch (PDOException $e) {
             throw new Exception('sqlauth:' . $this->authId .
                                 ': - Failed to prepare query: ' . $e->getMessage());
@@ -264,7 +264,7 @@ class SQL extends UserPassBase
         $numQueries = count($this->query);
         for ($x = 0; $x < $numQueries; $x++) {
             
-            $data = $this->executeQuery($this->query[$x], $params);
+            $data = $this->executeQuery($db, $this->query[$x], $params);
             
             Logger::info('sqlauth:' . $this->authId . ': Got ' . count($data) .
                 ' rows from database');

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -198,7 +198,7 @@ class SQL extends UserPassBase
      * @param array  $params parameters to the SQL query
      * @return tuples that result
      */
-    protected executeQuery( string $query, array $params ): array
+    protected function executeQuery( string $query, array $params ): array
     {
         try {
             $sth = $db->prepare($this->query[$x]);

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -52,7 +52,7 @@ class SQL extends \SimpleSAML\Module\core\Auth\UserPassBase
      * The username and password will be available as :username and :password.
      * @var string
      */
-    private string $query;
+    protected string $query;
 
     /**
      * Constructor for this authentication source.
@@ -95,7 +95,7 @@ class SQL extends \SimpleSAML\Module\core\Auth\UserPassBase
      *
      * @return \PDO  The database connection.
      */
-    private function connect(): PDO
+    protected function connect(): PDO
     {
         try {
             $db = new PDO($this->dsn, $this->username, $this->password, $this->options);

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -264,7 +264,7 @@ class SQL extends UserPassBase
         $numQueries = count($this->query);
         for ($x = 0; $x < $numQueries; $x++) {
             
-            $data = $this->executeQuery( $this->query[$x], $params )
+            $data = $this->executeQuery($this->query[$x], $params);
             
             Logger::info('sqlauth:' . $this->authId . ': Got ' . count($data) .
                 ' rows from database');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ require_once($projectRoot . '/vendor/autoload.php');
 
 // Load our wrapper class to get around login() being declared protected in SQL.php
 require_once($projectRoot . '/tests/src/Auth/Source/SQLWrapper.php');
+require_once($projectRoot . '/tests/src/Auth/Source/PasswordVerifyWrapper.php');
 
 // Symlink module into ssp vendor lib so that templates and urls can resolve correctly
 $linkPath = $projectRoot . '/vendor/simplesamlphp/simplesamlphp/modules/sqlauth';

--- a/tests/src/Auth/Source/PasswordVerifyWrapper.php
+++ b/tests/src/Auth/Source/PasswordVerifyWrapper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\Module\sqlauth\Auth\Source;
+
+use SimpleSAML\Module\sqlauth\Auth\Source\PasswordVerify;
+
+/**
+ * This class only exists to allow us to call the protected login() method.
+ * The calling method in UserPassBase.php doesn't return, so can't be used
+ * from PHPUnit. So we do this just to be able to unit test the login()
+ * method in PasswordVerify.php
+ */
+
+class PasswordVerifyWrapper extends PasswordVerify
+{
+    public function __construct(array $info, array $config)
+    {
+        parent::__construct($info, $config);
+    }
+
+    public function callLogin(string $username, string $password): array
+    {
+        return $this->login($username, $password);
+    }
+}


### PR DESCRIPTION
A new PasswordVerify.php method which is very much like the SQL class. The major difference is that instead of using SHA2 and other functions in the database we use the PHP `password_verify()` function to allow for example PASSWORD_ARGON2ID to be used for verification. The intention is to require less from the database itself so the selection of database used to supply passwords can be much larger.

While this class has a query parameter as the SQL class does the meaning is slightly different. The query for this class should return at least a column called `passwordhash` containing the hashed password which was generated 
for example using
```
 password_hash('hello', PASSWORD_ARGON2ID );
```  
Auth only passes if the PHP code below returns true.
```
 password_verify($password, row['passwordhash'] );
```
 
 Unlike the SQL class the username is the only parameter passed to the SQL query.  The query can not perform password checks, they are performed by the PHP code  in this class using password_verify().
 
If there are other columns in the returned data they are assumed to be attributes you would like to be returned through SAML.

This succeeds https://github.com/simplesamlphp/simplesamlphp-module-sqlauth/pull/4