### PR TITLE
Add username_regex option - run regular expresion over username before querying the database

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -19,6 +19,9 @@ Options
 `query`
 :   The SQL query or queries which should be used to authenticate the user and retrieve their attributes.
 
+`username_regex`
+:   (Optional) A regular expression that the username must match. Useful if the type of the username column in the database isn't a string (eg. an integer), or if the format is well known (eg. email address, single word with no spaces, etc) to avoid going to the database for a query that will never result in successful authentication.
+
 Writing a Query / Queries
 -------------------------
 
@@ -51,6 +54,7 @@ a basic entry with a single SQL string in `authsources.php` might look like this
         'username' => 'simplesaml',
         'password' => 'secretpassword',
         'query' => "select uid, givenName as \"givenName\", email from users where uid=:username and password=encode(sha512(concat((select salt from users where uid=1),  :password)::bytea), 'base64')",
+        'username_regex' => '/^[a-z]+$/', // Username will only be acceptable if it is a single lower case word
     ],
 ```
 

--- a/src/Auth/Source/SQL.php
+++ b/src/Auth/Source/SQL.php
@@ -173,7 +173,6 @@ class SQL extends UserPassBase
     {
         if ($this->username_regex !== null) {
             if (!preg_match($this->username_regex, $username)) {
-                // No rows returned from first query - invalid username/password
                 Logger::error('sqlauth:' . $this->authId .
                     ": Username doesn't match username_regex.");
                 throw new Error\Error('WRONGUSERPASS');

--- a/tests/src/Auth/Source/SQLTest.php
+++ b/tests/src/Auth/Source/SQLTest.php
@@ -84,6 +84,31 @@ class SQLTest extends TestCase
         ]);
     }
 
+    public function testBasicSingleUsernameRegexSuccess(): void
+    {
+        // Correct username/password
+        $this->config['query'] = "select givenName, email from users where uid=:username and password=:password";
+        $this->config['username_regex'] = '/^[a-z]+$/'; // Username will only be acceptable if it is a single lower case word
+        $ret = (new SQLWrapper($this->info, $this->config))->callLogin('bob', 'password');
+        asort($ret);
+        $this->assertCount(2, $ret);
+        $this->assertEquals($ret, [
+            'email' => ['bob@example.com'],
+            'givenName' => ["Bob"],
+        ]);
+    }
+
+    public function testBasicSingleUsernameRegexFailedLogin(): void
+    {
+        $this->expectException(\SimpleSAML\Error\Error::class);
+        // Correct username/password, but doesn't match the username regex
+        $this->config['query'] = "select givenName, email from users where uid=:username and password=:password";
+        $this->config['username_regex'] = '/^\d+$/'; // Username will only be acceptable if it is a non-negative integer
+        $ret = (new SQLWrapper($this->info, $this->config))->callLogin('bob', 'password');
+        asort($ret);
+        $this->assertCount(0, $ret);
+    }
+
     public function testBasicSingleFailedLogin()
     {
         $this->expectException(\SimpleSAML\Error\Error::class);

--- a/tests/src/Auth/Source/SQLTest.php
+++ b/tests/src/Auth/Source/SQLTest.php
@@ -88,7 +88,7 @@ class SQLTest extends TestCase
     {
         // Correct username/password
         $this->config['query'] = "select givenName, email from users where uid=:username and password=:password";
-        $this->config['username_regex'] = '/^[a-z]+$/'; // Username will only be acceptable if it is a single lower case word
+        $this->config['username_regex'] = '/^[a-z]+$/'; // Username must be a single lower case word
         $ret = (new SQLWrapper($this->info, $this->config))->callLogin('bob', 'password');
         asort($ret);
         $this->assertCount(2, $ret);
@@ -103,7 +103,7 @@ class SQLTest extends TestCase
         $this->expectException(\SimpleSAML\Error\Error::class);
         // Correct username/password, but doesn't match the username regex
         $this->config['query'] = "select givenName, email from users where uid=:username and password=:password";
-        $this->config['username_regex'] = '/^\d+$/'; // Username will only be acceptable if it is a non-negative integer
+        $this->config['username_regex'] = '/^\d+$/'; // Username must be a non-negative integer
         $ret = (new SQLWrapper($this->info, $this->config))->callLogin('bob', 'password');
         asort($ret);
         $this->assertCount(0, $ret);


### PR DESCRIPTION
This PR adds a new option `username_regex`, which checks the username against a regular expression before querying the database.

The use case that is affecting us is that our `username` column in our database is an integer (it's a customer ID), not a text/varchar. Whenever somebody types in a non-integer value they get an ugly stracktrace error from SimpleSAMLphp, rather than just the "wrong username and/or password" flow that it should trigger.

More generally, it can also be used to limit database queries to those which have some chance of succeeding (eg. I know it's an email address, I know it's a single word with no spaces or special characters, etc) - basic sanitization of the `username` parameter. These cases are more optimizations though to prevent a small amount of unnecessary database load.

Test cases are included and documentation updated.