### PR TITLE
Include sqlite3 php extension in the GH actions tests on Windows

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -162,7 +162,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, openssl, pcre, pdo, posix, spl, xml
+          extensions: ctype, date, dom, fileinfo, filter, hash, intl, mbstring, openssl, pcre, pdo, posix, spl, sqlite3, xml
           tools: composer
           ini-values: error_reporting=E_ALL
           coverage: pcov


### PR DESCRIPTION
The SQLite3 module is included by default on Linux, but not on Windows - see https://www.php.net/manual/en/sqlite3.installation.php. This PR fixes that so that the tests execute on Windows and Linux.

I don't think I can test this until it is merged - I believe for security reasons it always runs GitHub actions from master against the PR branch, not the GH Actions in the PR branch itself.